### PR TITLE
fix: Error llamada apis publicas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,12 +128,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.orm</groupId>
-      <artifactId>hibernate-envers</artifactId>
-      <version>6.5.1.Final</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.5.0</version>

--- a/src/main/java/com/example/demo/auth/AuthService.java
+++ b/src/main/java/com/example/demo/auth/AuthService.java
@@ -111,8 +111,9 @@ public class AuthService {
         .password(passwordEncoder.encode(request.getPassword()))
         .fcmToken(request.getFcmToken())
         .build();
+    User userSaved;
+    userSaved = userRepository.save(user);
 
-    User userSaved = userRepository.save(user);
     String token = jwtService.getToken(user);
 
     UserResponse response = UserResponse.builder()

--- a/src/main/java/com/example/demo/config/AuditorAwareImpl.java
+++ b/src/main/java/com/example/demo/config/AuditorAwareImpl.java
@@ -1,9 +1,13 @@
 package com.example.demo.config;
 
+import com.example.demo.dto.RegisterRequest;
 import com.example.demo.entity.AuditoryRevision;
 import com.example.demo.jwt.JwtService;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwt;
 import io.micrometer.common.lang.NonNullApi;
+import java.io.IOException;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -12,6 +16,7 @@ import org.hibernate.envers.RevisionEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.JsonComponentModule;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;
@@ -29,18 +34,11 @@ public class AuditorAwareImpl implements AuditorAware<AuditoryRevision> {
 
   private final JwtService jwtService;
 
-  private static final String[] IP_HEADER_CANDIDATES = {
-      "X-Forwarded-For",
-      "Proxy-Client-IP",
-      "WL-Proxy-Client-IP",
-      "HTTP_X_FORWARDED_FOR",
-      "HTTP_X_FORWARDED",
-      "HTTP_X_CLUSTER_CLIENT_IP",
-      "HTTP_CLIENT_IP",
-      "HTTP_FORWARDED_FOR",
-      "HTTP_FORWARDED",
-      "HTTP_VIA",
-      "REMOTE_ADDR"};
+  private static final String[] IP_HEADER_CANDIDATES = {"X-Forwarded-For", "Proxy-Client-IP",
+      "WL-Proxy-Client-IP", "HTTP_X_FORWARDED_FOR", "HTTP_X_FORWARDED", "HTTP_X_CLUSTER_CLIENT_IP",
+      "HTTP_CLIENT_IP", "HTTP_FORWARDED_FOR", "HTTP_FORWARDED", "HTTP_VIA", "REMOTE_ADDR"};
+  private final ObjectMapper jacksonObjectMapper;
+  private final JsonComponentModule jsonComponentModule;
 
   @Override
   public Optional<AuditoryRevision> getCurrentAuditor() {
@@ -73,7 +71,19 @@ public class AuditorAwareImpl implements AuditorAware<AuditoryRevision> {
   }
 
   private String getUsername(HttpServletRequest request) {
-    return jwtService.getUsernameFromToken(jwtService.getTokenFromRequest(request));
+    try {
+      if (jwtService.getTokenFromRequest(request) != null) {
+        return jwtService.getUsernameFromToken(jwtService.getTokenFromRequest(request));
+      }
+      RegisterRequest registerRequest = jacksonObjectMapper.readValue(
+          new String(request.getInputStream().readAllBytes(), request.getCharacterEncoding()),
+          RegisterRequest.class);
+      if (registerRequest.getUsername() != null) {
+        return registerRequest.getUsername();
+      }
+    } catch (Exception e) {
+      return "";
+    }
+    return "";
   }
-
 }

--- a/src/main/java/com/example/demo/config/FilterConfig.java
+++ b/src/main/java/com/example/demo/config/FilterConfig.java
@@ -35,7 +35,7 @@ public class FilterConfig implements Filter {
         try {
             assert req instanceof HttpServletRequest;
             chain.doFilter(new CachedBodyHttpServletRequestConfig((HttpServletRequest) req, requestBody), resp);
-        } catch (IOException | ServletException ex) {
+        } catch (Exception ex) {
             String errorMessage = ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage();
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);


### PR DESCRIPTION
Al auditar las llamadas publicas se obtiene del bearer token el username, si no tenia bearer token fallaba y la llamada no funcionaba. Tambien se elimina una libreria que no es necesaria.